### PR TITLE
Fix `pickle.json`

### DIFF
--- a/src/main/resources/data/culturalrecipes/recipe/fermenting/pickle.json
+++ b/src/main/resources/data/culturalrecipes/recipe/fermenting/pickle.json
@@ -1,7 +1,6 @@
 {
-  "type": "brewinandchewin:fermenting"
-},
-    "experience": 0.6,
+  "type": "brewinandchewin:fermenting",
+  "experience": 0.6,
   "fermentingtime": 12000,
   "ingredients": [
     {


### PR DESCRIPTION
- Removed extra `}` symbol that breaks the recipe.

Fixes this error in logs:
```log
[Render thread/ERROR] [net.minecraft.world.item.crafting.RecipeManager/]: Parsing error loading recipe culturalrecipes:fermenting/pickle: com.google.gson.JsonParseException: No key result in MapLike[{"type":"brewinandchewin:fermenting"}]; No key ingredients in MapLike[{"type":"brewinandchewin:fermenting"}]
```