### PR TITLE
Fix data and bump versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ repositories {
             name = "ModMaven"
             url = "https://modmaven.dev"
         }
+        maven {
+            // location of the maven that hosts Brewin and Chewin
+            name = "Greenhouse Maven"
+            url = "https://repo.greenhouse.house/releases/"
+        }
     }
     // Appleskin
     maven { url "https://maven.ryanliptak.com/" }
@@ -133,7 +138,9 @@ dependencies {
     implementation "maven.modrinth:farmers-delight:${project.farmers_delight_version}"
     //implementation "maven.modrinth:jei:${project.jei_version}"
     runtimeOnly("mezz.jei:jei-1.21.1-neoforge:${jei_version}")
-
+    implementation("umpaz.brewinandchewin:BrewinAndChewin-neoforge:${bnc_version}+${minecraft_version}") { transitive false }
+    implementation("house.greenhouse:greenhouseconfig:${greenhouse_config_version}-neoforge")
+    implementation("house.greenhouse:greenhouseconfig_toml:${greenhouse_toml_version}")
     localRuntime "maven.modrinth:appleskin:${project.appleskin_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1, 1.22)
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.85
+neo_version=21.1.185
 # The Neo version range can use any version of Neo as bounds
 neo_version_range=[21.1.0,)
 # The loader version range can only use the major version of FML as bounds
@@ -45,8 +45,11 @@ mod_authors=Developer: NCP Bails | Art: NCP Bails, Raspmary, Bagels, Nive
 mod_description=A Farmer's Delight addon that adds food systems from around the world.
 
 # Dependencies
-farmers_delight_version=1.21-1.2.4
+farmers_delight_version=1.21.1-1.2.8
 #appleskin_version=mc1.21-3.0.4
 appleskin_version=3.0.5+mc1.21
 #jei_version=19.5.0.31
 jei_version=19.21.0.247
+bnc_version=4.4.1
+greenhouse_config_version=2.2.0+1.21.1
+greenhouse_toml_version=1.1.0

--- a/src/main/resources/data/culturaldelights/loot_table/blocks/avocado_bundle.json
+++ b/src/main/resources/data/culturaldelights/loot_table/blocks/avocado_bundle.json
@@ -13,14 +13,14 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": 1
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],
@@ -32,8 +32,8 @@
                 {
                   "function": "minecraft:set_count",
                   "count": {
-                    "min": 2.0,
-                    "max": 4.0,
+                    "min": 2,
+                    "max": 4,
                     "type": "minecraft:uniform"
                   }
                 },

--- a/src/main/resources/data/culturaldelights/loot_table/blocks/avocado_leaves.json
+++ b/src/main/resources/data/culturaldelights/loot_table/blocks/avocado_leaves.json
@@ -2,8 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -12,27 +12,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
-                  "condition": "minecraft:alternative",
+                  "condition": "minecraft:any_of",
                   "terms": [
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": [
-                          "minecraft:shears"
-                        ]
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "enchantments": [
-                          {
-                            "enchantment": "minecraft:silk_touch",
-                            "levels": {
-                              "min": 1
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "minecraft:silk_touch",
+                              "levels": 1
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
                     }
                   ]
@@ -64,8 +62,8 @@
       ]
     },
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -87,8 +85,8 @@
               "function": "minecraft:set_count",
               "count": {
                 "type": "minecraft:uniform",
-                "min": 1.0,
-                "max": 2.0
+                "min": 1,
+                "max": 2
               },
               "add": false
             },
@@ -103,27 +101,25 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": [
-                    "minecraft:shears"
-                  ]
+                  "items": "#c:tools/shear"
                 }
               },
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
+                  "predicates": {
+                    "minecraft:enchantments": [
+                      {
+                        "enchantments": "minecraft:silk_touch",
+                        "levels": 1
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             ]
@@ -132,8 +128,8 @@
       ]
     },
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -160,27 +156,25 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": [
-                    "minecraft:shears"
-                  ]
+                  "items": "#c:tools/shear"
                 }
               },
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
+                  "predicates": {
+                    "minecraft:enchantments": [
+                      {
+                        "enchantments": "minecraft:silk_touch",
+                        "levels": 1
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             ]

--- a/src/main/resources/data/culturaldelights/loot_table/blocks/fruiting_avocado_leaves.json
+++ b/src/main/resources/data/culturaldelights/loot_table/blocks/fruiting_avocado_leaves.json
@@ -2,8 +2,8 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:alternatives",
@@ -12,27 +12,25 @@
               "type": "minecraft:item",
               "conditions": [
                 {
-                  "condition": "minecraft:alternative",
+                  "condition": "minecraft:any_of",
                   "terms": [
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "items": [
-                          "minecraft:shears"
-                        ]
+                        "items": "#c:tools/shear"
                       }
                     },
                     {
                       "condition": "minecraft:match_tool",
                       "predicate": {
-                        "enchantments": [
-                          {
-                            "enchantment": "minecraft:silk_touch",
-                            "levels": {
-                              "min": 1
+                        "predicates": {
+                          "minecraft:enchantments": [
+                            {
+                              "enchantments": "minecraft:silk_touch",
+                              "levels": 1
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
                     }
                   ]
@@ -64,8 +62,8 @@
       ]
     },
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -87,8 +85,8 @@
               "function": "minecraft:set_count",
               "count": {
                 "type": "minecraft:uniform",
-                "min": 1.0,
-                "max": 2.0
+                "min": 1,
+                "max": 2
               },
               "add": false
             },
@@ -103,27 +101,25 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": [
-                    "minecraft:shears"
-                  ]
+                  "items": "#c:tools/shear"
                 }
               },
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
+                  "predicates": {
+                    "minecraft:enchantments": [
+                      {
+                        "enchantments": "minecraft:silk_touch",
+                        "levels": 1
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             ]
@@ -132,8 +128,8 @@
       ]
     },
     {
-      "rolls": 1.0,
-      "bonus_rolls": 0.0,
+      "rolls": 1,
+      "bonus_rolls": 0,
       "entries": [
         {
           "type": "minecraft:item",
@@ -160,27 +156,25 @@
         {
           "condition": "minecraft:inverted",
           "term": {
-            "condition": "minecraft:alternative",
+            "condition": "minecraft:any_of",
             "terms": [
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "items": [
-                    "minecraft:shears"
-                  ]
+                  "items": "#c:tools/shear"
                 }
               },
               {
                 "condition": "minecraft:match_tool",
                 "predicate": {
-                  "enchantments": [
-                    {
-                      "enchantment": "minecraft:silk_touch",
-                      "levels": {
-                        "min": 1
+                  "predicates": {
+                    "minecraft:enchantments": [
+                      {
+                        "enchantments": "minecraft:silk_touch",
+                        "levels": 1
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
               }
             ]

--- a/src/main/resources/data/culturalrecipes/recipe/fermenting/pickle.json
+++ b/src/main/resources/data/culturalrecipes/recipe/fermenting/pickle.json
@@ -1,7 +1,6 @@
 {
-  "type": "brewinandchewin:fermenting"
-},
-    "experience": 0.6,
+  "type": "brewinandchewin:fermenting",
+  "experience": 0.6,
   "fermentingtime": 12000,
   "ingredients": [
     {
@@ -20,7 +19,7 @@
   "recipe_book_tab": "misc",
   "result": {
     "count": 4,
-    "item": "culturaldelights:pickle"
+    "id": "culturaldelights:pickle"
   },
   "temperature": 2
 }


### PR DESCRIPTION
- Fixes loot tables for Avocado Leaves and Fruiting Avocado Leaves
- Fixes Brewin and Chewin fermenting recipe - similar to #6 but also fixes the 1.21 item/id switch.
- Bumped Neo and FD dependencies and added Brewin and Chewin as a compile dependency to help spot issues sooner.