### PR TITLE
Fix corn_upper for en_us and ko_kr

### DIFF
--- a/src/main/resources/assets/culturaldelights/lang/en_us.json
+++ b/src/main/resources/assets/culturaldelights/lang/en_us.json
@@ -58,7 +58,7 @@
   "block.culturaldelights.cucumbers": "Cucumbers",
   "block.culturaldelights.eggplants": "Eggplants",
   "block.culturaldelights.corn": "Corn",
-  "block.culturaldelights.corn": "Corn Upper",
+  "block.culturaldelights.corn_upper": "Corn Upper",
 
   "block.culturaldelights.avocado_bundle": "Avocado Bundle",
   "block.culturaldelights.wild_cucumbers": "Wild Cucumbers",

--- a/src/main/resources/assets/culturaldelights/lang/ko_kr.json
+++ b/src/main/resources/assets/culturaldelights/lang/ko_kr.json
@@ -58,7 +58,7 @@
   "block.culturaldelights.cucumbers": "Cucumbers",
   "block.culturaldelights.eggplants": "Eggplants",
   "block.culturaldelights.corn": "Corn",
-  "block.culturaldelights.corn": "Corn Upper",
+  "block.culturaldelights.corn_upper": "Corn Upper",
 
   "block.culturaldelights.avocado_bundle": "아보카도 꾸러미",
   "block.culturaldelights.wild_cucumbers": "야생 오이",


### PR DESCRIPTION
<img width="371" height="54" alt="изображение" src="https://github.com/user-attachments/assets/5fa41723-0584-40fb-9267-a851ca087fbc" />

Noticed an issue in English and Korean with “block.culturaldelights.corn_upper”: “Corn Upper”