### PR TITLE
Tags fix

### DIFF
--- a/src/main/resources/assets/culturaldelights/lang/de_de.json
+++ b/src/main/resources/assets/culturaldelights/lang/de_de.json
@@ -73,5 +73,23 @@
   "block.culturaldelights.pickle_crate": "Essiggurken Kiste",
   "block.culturaldelights.corn_cob_crate": "Maiskolben Kiste",
   "block.culturaldelights.eggplant_crate": "Auberginen Kiste",
-  "block.culturaldelights.white_eggplant_crate": "Weiße Auberginen Kiste"
+  "block.culturaldelights.white_eggplant_crate": "Weiße Auberginen Kiste",
+
+  "tag.item.c.crops.avocado": "Avocado",
+  "tag.item.c.crops.cucumber": "Gurke",
+  "tag.item.c.crops.eggplant": "Aubergine",
+  "tag.item.c.crops.corn": "Mais",
+  "tag.item.c.crops.rice": "Reis",
+  "tag.item.c.crops.onion": "Zwiebel",
+  "tag.item.c.crops.tomato": "Tomate",
+
+  "tag.item.c.foods.bread": "Brot",
+  "tag.item.c.foods.cooked_egg": "Gekochtes Ei",
+  "tag.item.c.foods.cooked_fish": "Gekochter Fisch",
+  "tag.item.c.foods.cooked_mutton": "Gekochtes Hammelfleisch",
+  "tag.item.c.foods.leafy_green": "Blattgemüse",
+  "tag.item.c.foods.milk": "Milch",
+
+  "tag.item.c.logs.avocado": "Avocado-Holz",
+  "tag.item.c.eggs": "Eier"
 }

--- a/src/main/resources/assets/culturaldelights/lang/en_us.json
+++ b/src/main/resources/assets/culturaldelights/lang/en_us.json
@@ -90,5 +90,23 @@
   "tag.item.culturaldelights.cucumbers": "Cucumbers",
   "tag.item.culturaldelights.raw_salmons": "Raw Salmon",
   "tag.item.culturaldelights.regular_eggplants": "Regular Eggplants",
-  "tag.item.culturaldelights.smoked_regular_eggplants": "Smoked Regular Eggplants"
+  "tag.item.culturaldelights.smoked_regular_eggplants": "Smoked Regular Eggplants",
+
+  "tag.item.c.crops.avocado": "Avocado",
+  "tag.item.c.crops.cucumber": "Cucumber",
+  "tag.item.c.crops.eggplant": "Eggplant",
+  "tag.item.c.crops.corn": "Corn",
+  "tag.item.c.crops.rice": "Rice",
+  "tag.item.c.crops.onion": "Onion",
+  "tag.item.c.crops.tomato": "Tomato",
+
+  "tag.item.c.foods.bread": "Bread",
+  "tag.item.c.foods.cooked_egg": "Cooked Egg",
+  "tag.item.c.foods.cooked_fish": "Cooked Fish",
+  "tag.item.c.foods.cooked_mutton": "Cooked Mutton",
+  "tag.item.c.foods.leafy_green": "Leafy Greens",
+  "tag.item.c.foods.milk": "Milk",
+
+  "tag.item.c.logs.avocado": "Avocado Logs",
+  "tag.item.c.eggs": "Eggs"
 }

--- a/src/main/resources/assets/culturaldelights/lang/fr_fr.json
+++ b/src/main/resources/assets/culturaldelights/lang/fr_fr.json
@@ -69,5 +69,23 @@
   "block.culturaldelights.eggplant_crate": "Caisse d'aubergines",
   "block.culturaldelights.white_eggplant_crate": "Caisse d'aubergines blanches",
 
-  "screen.culturaldelights.bamboo_mat": "Tapis de Bambou"
+  "screen.culturaldelights.bamboo_mat": "Tapis de Bambou",
+
+  "tag.item.c.crops.avocado": "Avocat",
+  "tag.item.c.crops.cucumber": "Concombre",
+  "tag.item.c.crops.eggplant": "Aubergine",
+  "tag.item.c.crops.corn": "Maïs",
+  "tag.item.c.crops.rice": "Riz",
+  "tag.item.c.crops.onion": "Oignon",
+  "tag.item.c.crops.tomato": "Tomate",
+
+  "tag.item.c.foods.bread": "Pain",
+  "tag.item.c.foods.cooked_egg": "Œuf cuit",
+  "tag.item.c.foods.cooked_fish": "Poisson cuit",
+  "tag.item.c.foods.cooked_mutton": "Mouton cuit",
+  "tag.item.c.foods.leafy_green": "Légumes-feuilles",
+  "tag.item.c.foods.milk": "Lait",
+
+  "tag.item.c.logs.avocado": "Bûches d'avocat",
+  "tag.item.c.eggs": "Œufs"
 }

--- a/src/main/resources/assets/culturaldelights/lang/ja_jp.json
+++ b/src/main/resources/assets/culturaldelights/lang/ja_jp.json
@@ -58,7 +58,7 @@
   "block.culturaldelights.cucumbers": "キュウリ",
   "block.culturaldelights.eggplants": "ナス",
   "block.culturaldelights.corn": "トウモロコシ",
-  "block.culturaldelights.corn": "トウモロコシの穂",
+  "block.culturaldelights.corn_upper": "トウモロコシの穂",
 
   "block.culturaldelights.avocado_bundle": "束ねたアボカド",
   "block.culturaldelights.wild_cucumbers": "野生のキュウリ",
@@ -75,7 +75,7 @@
   "block.culturaldelights.pickle_crate": "ピクルス入り木箱",
   "block.culturaldelights.corn_cob_crate": "トウモロコシ入り木箱",
   "block.culturaldelights.eggplant_crate": "ナス入り木箱",
-  "block.culturaldelights.white_eggplant_crate": "白ナス入り木箱"
+  "block.culturaldelights.white_eggplant_crate": "白ナス入り木箱",
   "block.culturaldelights.eggplant_parmesan_block": "ナスのパルメザングラタン",
 
   "creativetab.culturaldelights.culturaldelights_tab": "Cultural Delights",
@@ -90,5 +90,23 @@
   "tag.item.culturaldelights.cucumbers": "キュウリ",
   "tag.item.culturaldelights.raw_salmons": "生鮭",
   "tag.item.culturaldelights.regular_eggplants": "一般的なナス",
-  "tag.item.culturaldelights.smoked_regular_eggplants": "燻製した一般的なナス"
+  "tag.item.culturaldelights.smoked_regular_eggplants": "燻製した一般的なナス",
+
+  "tag.item.c.crops.avocado": "アボカド",
+  "tag.item.c.crops.cucumber": "キュウリ",
+  "tag.item.c.crops.eggplant": "ナス",
+  "tag.item.c.crops.corn": "トウモロコシ",
+  "tag.item.c.crops.rice": "米",
+  "tag.item.c.crops.onion": "タマネギ",
+  "tag.item.c.crops.tomato": "トマト",
+
+  "tag.item.c.foods.bread": "パン",
+  "tag.item.c.foods.cooked_egg": "焼き卵",
+  "tag.item.c.foods.cooked_fish": "焼き魚",
+  "tag.item.c.foods.cooked_mutton": "調理した羊肉",
+  "tag.item.c.foods.leafy_green": "葉物野菜",
+  "tag.item.c.foods.milk": "ミルク",
+
+  "tag.item.c.logs.avocado": "アボカドの原木",
+  "tag.item.c.eggs": "卵"
 }

--- a/src/main/resources/assets/culturaldelights/lang/kk_kz.json
+++ b/src/main/resources/assets/culturaldelights/lang/kk_kz.json
@@ -90,5 +90,23 @@
   "tag.item.culturaldelights.cucumbers": "Қиярлар",
   "tag.item.culturaldelights.raw_salmons": "Шикі албырт",
   "tag.item.culturaldelights.regular_eggplants": "Қарапайым баялдылар",
-  "tag.item.culturaldelights.smoked_regular_eggplants": "Сүрленген қарапайым баялдылар"
+  "tag.item.culturaldelights.smoked_regular_eggplants": "Сүрленген қарапайым баялдылар",
+
+  "tag.item.c.crops.avocado": "Авокадо",
+  "tag.item.c.crops.cucumber": "Қияр",
+  "tag.item.c.crops.eggplant": "Баялды",
+  "tag.item.c.crops.corn": "Жүгері",
+  "tag.item.c.crops.rice": "Күріш",
+  "tag.item.c.crops.onion": "Пияз",
+  "tag.item.c.crops.tomato": "Қызанақ",
+
+  "tag.item.c.foods.bread": "Нан",
+  "tag.item.c.foods.cooked_egg": "Піскен жұмыртқа",
+  "tag.item.c.foods.cooked_fish": "Піскен балық",
+  "tag.item.c.foods.cooked_mutton": "Піскен қой еті",
+  "tag.item.c.foods.leafy_green": "Жапырақты көктер",
+  "tag.item.c.foods.milk": "Сүт",
+
+  "tag.item.c.logs.avocado": "Авокадо діңгектері",
+  "tag.item.c.eggs": "Жұмыртқалар"
 }

--- a/src/main/resources/assets/culturaldelights/lang/ko_kr.json
+++ b/src/main/resources/assets/culturaldelights/lang/ko_kr.json
@@ -75,5 +75,23 @@
   "block.culturaldelights.pickle_crate": "피클 상자",
   "block.culturaldelights.corn_cob_crate": "옥수수 상자",
   "block.culturaldelights.eggplant_crate": "가지 상자",
-  "block.culturaldelights.white_eggplant_crate": "흰가지 상자"
+  "block.culturaldelights.white_eggplant_crate": "흰가지 상자",
+
+  "tag.item.c.crops.avocado": "아보카도",
+  "tag.item.c.crops.cucumber": "오이",
+  "tag.item.c.crops.eggplant": "가지",
+  "tag.item.c.crops.corn": "옥수수",
+  "tag.item.c.crops.rice": "쌀",
+  "tag.item.c.crops.onion": "양파",
+  "tag.item.c.crops.tomato": "토마토",
+
+  "tag.item.c.foods.bread": "빵",
+  "tag.item.c.foods.cooked_egg": "익힌 달걀",
+  "tag.item.c.foods.cooked_fish": "익힌 생선",
+  "tag.item.c.foods.cooked_mutton": "익힌 양고기",
+  "tag.item.c.foods.leafy_green": "잎채소",
+  "tag.item.c.foods.milk": "우유",
+
+  "tag.item.c.logs.avocado": "아보카도 원목",
+  "tag.item.c.eggs": "달걀"
 }

--- a/src/main/resources/assets/culturaldelights/lang/pt_br.json
+++ b/src/main/resources/assets/culturaldelights/lang/pt_br.json
@@ -69,5 +69,23 @@
   "block.culturaldelights.eggplant_crate": "Caixote de berinjelas",
   "block.culturaldelights.white_eggplant_crate": "Caixote de berinjelas brancas",
 
-  "screen.culturaldelights.bamboo_mat": "Tapete de bambu"
+  "screen.culturaldelights.bamboo_mat": "Tapete de bambu",
+
+  "tag.item.c.crops.avocado": "Abacate",
+  "tag.item.c.crops.cucumber": "Pepino",
+  "tag.item.c.crops.eggplant": "Berinjela",
+  "tag.item.c.crops.corn": "Milho",
+  "tag.item.c.crops.rice": "Arroz",
+  "tag.item.c.crops.onion": "Cebola",
+  "tag.item.c.crops.tomato": "Tomate",
+
+  "tag.item.c.foods.bread": "Pão",
+  "tag.item.c.foods.cooked_egg": "Ovo cozido",
+  "tag.item.c.foods.cooked_fish": "Peixe cozido",
+  "tag.item.c.foods.cooked_mutton": "Carneiro cozido",
+  "tag.item.c.foods.leafy_green": "Verduras",
+  "tag.item.c.foods.milk": "Leite",
+
+  "tag.item.c.logs.avocado": "Troncos de abacate",
+  "tag.item.c.eggs": "Ovos"
 }

--- a/src/main/resources/assets/culturaldelights/lang/ru_ru.json
+++ b/src/main/resources/assets/culturaldelights/lang/ru_ru.json
@@ -90,5 +90,23 @@
   "tag.item.culturaldelights.cucumbers": "Огурцы",
   "tag.item.culturaldelights.raw_salmons": "Сырой лосось",
   "tag.item.culturaldelights.regular_eggplants": "Обычные баклажаны",
-  "tag.item.culturaldelights.smoked_regular_eggplants": "Копчёные обычные баклажаны"
+  "tag.item.culturaldelights.smoked_regular_eggplants": "Копчёные обычные баклажаны",
+
+  "tag.item.c.crops.avocado": "Авокадо",
+  "tag.item.c.crops.cucumber": "Огурец",
+  "tag.item.c.crops.eggplant": "Баклажан",
+  "tag.item.c.crops.corn": "Кукуруза",
+  "tag.item.c.crops.rice": "Рис",
+  "tag.item.c.crops.onion": "Лук",
+  "tag.item.c.crops.tomato": "Томат",
+
+  "tag.item.c.foods.bread": "Хлеб",
+  "tag.item.c.foods.cooked_egg": "Приготовленное яйцо",
+  "tag.item.c.foods.cooked_fish": "Приготовленная рыба",
+  "tag.item.c.foods.cooked_mutton": "Приготовленная баранина",
+  "tag.item.c.foods.leafy_green": "Листовая зелень",
+  "tag.item.c.foods.milk": "Молоко",
+
+  "tag.item.c.logs.avocado": "Брёвна авокадо",
+  "tag.item.c.eggs": "Яйца"
 }

--- a/src/main/resources/assets/culturaldelights/lang/tr_tr.json
+++ b/src/main/resources/assets/culturaldelights/lang/tr_tr.json
@@ -79,5 +79,23 @@
 
   "_comment.english": "Intentionally untranslated, as this is the mod's name",
   "_comment.turkish": "Modun adı olduğu için bilerek çevrilmedi",
-  "creativetab.culturaldelights.culturaldelights_tab": "Cultural Delights"
+  "creativetab.culturaldelights.culturaldelights_tab": "Cultural Delights",
+
+  "tag.item.c.crops.avocado": "Avokado",
+  "tag.item.c.crops.cucumber": "Salatalık",
+  "tag.item.c.crops.eggplant": "Patlıcan",
+  "tag.item.c.crops.corn": "Mısır",
+  "tag.item.c.crops.rice": "Pirinç",
+  "tag.item.c.crops.onion": "Soğan",
+  "tag.item.c.crops.tomato": "Domates",
+
+  "tag.item.c.foods.bread": "Ekmek",
+  "tag.item.c.foods.cooked_egg": "Pişmiş yumurta",
+  "tag.item.c.foods.cooked_fish": "Pişmiş balık",
+  "tag.item.c.foods.cooked_mutton": "Pişmiş koyun eti",
+  "tag.item.c.foods.leafy_green": "Yapraklı yeşillikler",
+  "tag.item.c.foods.milk": "Süt",
+
+  "tag.item.c.logs.avocado": "Avokado kütükleri",
+  "tag.item.c.eggs": "Yumurtalar"
 }

--- a/src/main/resources/assets/culturaldelights/lang/uk_ua.json
+++ b/src/main/resources/assets/culturaldelights/lang/uk_ua.json
@@ -73,5 +73,23 @@
   "block.culturaldelights.pickle_crate": "Ящик маринованих огірків",
   "block.culturaldelights.corn_cob_crate": "Ящик кукурудзи",
   "block.culturaldelights.eggplant_crate": "Ящик баклажанів",
-  "block.culturaldelights.white_eggplant_crate": "Ящик білих баклажанів"
+  "block.culturaldelights.white_eggplant_crate": "Ящик білих баклажанів",
+
+  "tag.item.c.crops.avocado": "Авокадо",
+  "tag.item.c.crops.cucumber": "Огірок",
+  "tag.item.c.crops.eggplant": "Баклажан",
+  "tag.item.c.crops.corn": "Кукурудза",
+  "tag.item.c.crops.rice": "Рис",
+  "tag.item.c.crops.onion": "Цибуля",
+  "tag.item.c.crops.tomato": "Помідор",
+
+  "tag.item.c.foods.bread": "Хліб",
+  "tag.item.c.foods.cooked_egg": "Приготоване яйце",
+  "tag.item.c.foods.cooked_fish": "Приготована риба",
+  "tag.item.c.foods.cooked_mutton": "Приготована баранина",
+  "tag.item.c.foods.leafy_green": "Листова зелень",
+  "tag.item.c.foods.milk": "Молоко",
+
+  "tag.item.c.logs.avocado": "Колоди авокадо",
+  "tag.item.c.eggs": "Яйця"
 }

--- a/src/main/resources/assets/culturaldelights/lang/zh_cn.json
+++ b/src/main/resources/assets/culturaldelights/lang/zh_cn.json
@@ -58,7 +58,7 @@
   "block.culturaldelights.cucumbers": "黄瓜",
   "block.culturaldelights.eggplants": "茄子",
   "block.culturaldelights.corn": "玉米",
-  "block.culturaldelights.corn": "玉米上部",
+  "block.culturaldelights.corn_upper": "玉米上部",
 
   "block.culturaldelights.avocado_bundle": "牛油果捆",
   "block.culturaldelights.wild_cucumbers": "野生黄瓜",
@@ -90,5 +90,22 @@
   "tag.item.culturaldelights.cucumbers": "黄瓜",
   "tag.item.culturaldelights.raw_salmons": "生鲑鱼",
   "tag.item.culturaldelights.regular_eggplants": "常规茄子",
-  "tag.item.culturaldelights.smoked_regular_eggplants": "常规烟熏茄子"
+  "tag.item.culturaldelights.smoked_regular_eggplants": "常规烟熏茄子",
+  "tag.item.c.crops.avocado": "牛油果",
+  "tag.item.c.crops.cucumber": "黄瓜",
+  "tag.item.c.crops.eggplant": "茄子",
+  "tag.item.c.crops.corn": "玉米",
+  "tag.item.c.crops.rice": "大米",
+  "tag.item.c.crops.onion": "洋葱",
+  "tag.item.c.crops.tomato": "番茄",
+
+  "tag.item.c.foods.bread": "面包",
+  "tag.item.c.foods.cooked_egg": "熟鸡蛋",
+  "tag.item.c.foods.cooked_fish": "熟鱼",
+  "tag.item.c.foods.cooked_mutton": "熟羊肉",
+  "tag.item.c.foods.leafy_green": "绿叶菜",
+  "tag.item.c.foods.milk": "牛奶",
+
+  "tag.item.c.logs.avocado": "牛油果原木",
+  "tag.item.c.eggs": "鸡蛋"
 }

--- a/src/main/resources/assets/culturaldelights/lang/zh_tw.json
+++ b/src/main/resources/assets/culturaldelights/lang/zh_tw.json
@@ -76,5 +76,23 @@
   "block.culturaldelights.pickle_crate": "醃黃瓜箱",
   "block.culturaldelights.corn_cob_crate": "玉米箱",
   "block.culturaldelights.eggplant_crate": "茄子箱",
-  "block.culturaldelights.white_eggplant_crate": "白茄子箱"
+  "block.culturaldelights.white_eggplant_crate": "白茄子箱",
+
+  "tag.item.c.crops.avocado": "酪梨",
+  "tag.item.c.crops.cucumber": "小黃瓜",
+  "tag.item.c.crops.eggplant": "茄子",
+  "tag.item.c.crops.corn": "玉米",
+  "tag.item.c.crops.rice": "米",
+  "tag.item.c.crops.onion": "洋蔥",
+  "tag.item.c.crops.tomato": "番茄",
+
+  "tag.item.c.foods.bread": "麵包",
+  "tag.item.c.foods.cooked_egg": "熟蛋",
+  "tag.item.c.foods.cooked_fish": "熟魚",
+  "tag.item.c.foods.cooked_mutton": "熟羊肉",
+  "tag.item.c.foods.leafy_green": "葉菜",
+  "tag.item.c.foods.milk": "牛奶",
+
+  "tag.item.c.logs.avocado": "酪梨原木",
+  "tag.item.c.eggs": "蛋"
 }

--- a/src/main/resources/data/c/tags/item/crops/avocado.json
+++ b/src/main/resources/data/c/tags/item/crops/avocado.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#culturaldelights:avocados"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/crops/corn.json
+++ b/src/main/resources/data/c/tags/item/crops/corn.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "culturaldelights:corn_cob"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/crops/cucumber.json
+++ b/src/main/resources/data/c/tags/item/crops/cucumber.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#culturaldelights:cucumbers"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/crops/eggplant.json
+++ b/src/main/resources/data/c/tags/item/crops/eggplant.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#culturaldelights:all_eggplants"
+  ]
+}

--- a/src/main/resources/data/c/tags/item/logs/avocado.json
+++ b/src/main/resources/data/c/tags/item/logs/avocado.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#culturaldelights:avocado_logs"
+  ]
+}

--- a/src/main/resources/data/culturalrecipes/recipe/avocado_toast.json
+++ b/src/main/resources/data/culturalrecipes/recipe/avocado_toast.json
@@ -2,10 +2,10 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     {
       "item": "minecraft:bread"

--- a/src/main/resources/data/culturalrecipes/recipe/avocado_wood.json
+++ b/src/main/resources/data/culturalrecipes/recipe/avocado_wood.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "#": {
-      "item": "culturaldelights:avocado_log"
+      "tag": "c:logs/avocado"
     }
   },
   "result": {

--- a/src/main/resources/data/culturalrecipes/recipe/beef_burrito.json
+++ b/src/main/resources/data/culturalrecipes/recipe/beef_burrito.json
@@ -8,7 +8,7 @@
       "tag": "culturaldelights:cooked_beefs"
     },
     {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     {
       "item": "farmersdelight:cooked_rice"

--- a/src/main/resources/data/culturalrecipes/recipe/chicken_taco.json
+++ b/src/main/resources/data/culturalrecipes/recipe/chicken_taco.json
@@ -11,10 +11,10 @@
       "item": "farmersdelight:tomato_sauce"
     },
     {
-      "tag": "culturaldelights:cucumbers"
+      "tag": "c:crops/cucumber"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     }
   ],
   "result": {

--- a/src/main/resources/data/culturalrecipes/recipe/cooking/creamed_corn.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cooking/creamed_corn.json
@@ -11,10 +11,10 @@
       "tag": "c:foods/milk"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     }
   ],
   "recipe_book_tab": "meals",

--- a/src/main/resources/data/culturalrecipes/recipe/cooking/eggplant_parmesan_block.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cooking/eggplant_parmesan_block.json
@@ -8,7 +8,7 @@
   "experience": 2.0,
   "ingredients": [
     {
-      "tag": "culturaldelights:regular_eggplants"
+      "tag": "c:crops/eggplant"
     },
     {
       "tag": "c:foods/milk"

--- a/src/main/resources/data/culturalrecipes/recipe/cooking/elote.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cooking/elote.json
@@ -11,7 +11,7 @@
       "tag": "c:foods/milk"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     },
     {
       "tag": "c:crops/onion"

--- a/src/main/resources/data/culturalrecipes/recipe/cooking/poached_eggplants.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cooking/poached_eggplants.json
@@ -8,7 +8,7 @@
   "experience": 2.0,
   "ingredients": [
     {
-      "tag": "culturaldelights:regular_eggplants"
+      "tag": "c:crops/eggplant"
     },
     {
       "tag": "c:crops/onion"

--- a/src/main/resources/data/culturalrecipes/recipe/corn_dough.json
+++ b/src/main/resources/data/culturalrecipes/recipe/corn_dough.json
@@ -5,13 +5,13 @@
       "item": "minecraft:water_bucket"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     }
   ],
   "result": {

--- a/src/main/resources/data/culturalrecipes/recipe/cutting/avocado_log.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cutting/avocado_log.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "culturaldelights:avocado_log"
+      "tag": "c:logs/avocado"
     }
   ],
   "result": [

--- a/src/main/resources/data/culturalrecipes/recipe/cutting/corn_kernels.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cutting/corn_kernels.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     }
   ],
   "result": [

--- a/src/main/resources/data/culturalrecipes/recipe/cutting/cut_eggplant.json
+++ b/src/main/resources/data/culturalrecipes/recipe/cutting/cut_eggplant.json
@@ -2,7 +2,7 @@
   "type": "farmersdelight:cutting",
   "ingredients": [
     {
-      "item": "culturaldelights:eggplant"
+      "tag": "c:crops/eggplant"
     }
   ],
   "result": [

--- a/src/main/resources/data/culturalrecipes/recipe/empanada.json
+++ b/src/main/resources/data/culturalrecipes/recipe/empanada.json
@@ -8,7 +8,7 @@
       "item": "culturaldelights:corn_dough"
     },
     {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     {
       "tag": "c:crops/tomato"

--- a/src/main/resources/data/culturalrecipes/recipe/hearty_salad.json
+++ b/src/main/resources/data/culturalrecipes/recipe/hearty_salad.json
@@ -5,13 +5,13 @@
       "tag": "c:crops/tomato"
     },
     {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     {
-      "item": "culturaldelights:corn_cob"
+      "tag": "c:crops/corn"
     },
     {
-      "item": "culturaldelights:cucumber"
+      "tag": "c:crops/cucumber"
     },
     {
       "item": "minecraft:bowl"

--- a/src/main/resources/data/culturalrecipes/recipe/jungle_planks.json
+++ b/src/main/resources/data/culturalrecipes/recipe/jungle_planks.json
@@ -3,7 +3,7 @@
   "group": "planks",
   "ingredients": [
     {
-      "tag": "culturaldelights:avocado_logs"
+      "tag": "c:logs/avocado"
     }
   ],
   "result": {

--- a/src/main/resources/data/culturalrecipes/recipe/midori_roll.json
+++ b/src/main/resources/data/culturalrecipes/recipe/midori_roll.json
@@ -13,10 +13,10 @@
       "item": "farmersdelight:cooked_rice"
     },
     "?": {
-      "tag": "culturaldelights:avocados"
+      "tag": "c:crops/avocado"
     },
     "!": {
-      "tag": "culturaldelights:cucumbers"
+      "tag": "c:crops/cucumber"
     }
   },
   "result": {

--- a/src/main/resources/data/culturalrecipes/recipe/smelting/smoked_eggplant.json
+++ b/src/main/resources/data/culturalrecipes/recipe/smelting/smoked_eggplant.json
@@ -1,7 +1,7 @@
 {
   "type": "minecraft:smoking",
   "ingredient": {
-    "item": "culturaldelights:eggplant"
+    "tag": "c:crops/eggplant"
   },
   "result": {
     "count": 1,


### PR DESCRIPTION
This should fix the tag issue that this mod is facing. I added c:crops/NAME tags to the crops and logs (avocado) and changed the recipes to use tags instead where I felt it to be proper. 

This should fix compatability with other mods. And a quick test on my personal server looked promising although I have not tested this exhaustively. 

I am very inexperienced with minecraft modding though, and hope that this is correctly done.